### PR TITLE
feat(member): 마이페이지 API 구현 및 첫로그인 로직 개선

### DIFF
--- a/src/main/java/com/balsamic/sejongmalsami/controller/MemberController.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.balsamic.sejongmalsami.controller;
 
+import com.balsamic.sejongmalsami.object.CustomUserDetails;
 import com.balsamic.sejongmalsami.object.MemberCommand;
 import com.balsamic.sejongmalsami.object.MemberDto;
 import com.balsamic.sejongmalsami.service.MemberService;
@@ -8,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +31,15 @@ public class MemberController implements MemberControllerDocs {
   public ResponseEntity<MemberDto> signIn(
       @ModelAttribute MemberCommand command,
       HttpServletResponse response) {
-    MemberDto memberDto = memberService.signIn(command, response);
-    return ResponseEntity.ok(memberDto);
+    return ResponseEntity.ok(memberService.signIn(command, response));
+  }
+
+  @Override
+  @PostMapping(value = "/my-page", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<MemberDto> myPage(
+      @ModelAttribute MemberCommand command,
+      @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    command.setMemberId(customUserDetails.getMemberId());
+    return ResponseEntity.ok(memberService.myPage(command));
   }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/controller/MemberControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/MemberControllerDocs.java
@@ -1,5 +1,6 @@
 package com.balsamic.sejongmalsami.controller;
 
+import com.balsamic.sejongmalsami.object.CustomUserDetails;
 import com.balsamic.sejongmalsami.object.MemberCommand;
 import com.balsamic.sejongmalsami.object.MemberDto;
 import com.balsamic.sejongmalsami.object.constants.Author;
@@ -8,6 +9,7 @@ import com.balsamic.sejongmalsami.util.log.ApiChangeLogs;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
 public interface MemberControllerDocs {
@@ -86,4 +88,35 @@ public interface MemberControllerDocs {
   ResponseEntity<MemberDto> signIn(
       @ModelAttribute MemberCommand command,
       HttpServletResponse response);
+
+  @ApiChangeLogs({
+      @ApiChangeLog(
+          date = "2024.10.28",
+          author = Author.SUHSAECHAN,
+          description = "마이페이지 API init"
+      )
+  })
+  @Operation(
+      summary = "마이페이지",
+      description = """
+          **마이페이지**
+
+          **입력 파라미터 값:**
+
+          - **String sejongPortalId**: 세종대학교 포털 ID
+            _예: "18010561"_
+
+          **반환 파라미터 값:**
+
+          - **MemberDto**: 로그인 및 인증이 완료된 회원의 정보와 액세스 토큰
+            - **Member member**: 회원 정보
+
+          **참고 사항:**
+
+          - 이 API를 통해 회원은 세종대학교 포털 인증 정보를 이용하여 로그인할 수 있습니다.
+          """
+  )
+  ResponseEntity<MemberDto> myPage(
+      @ModelAttribute MemberCommand command,
+      @AuthenticationPrincipal CustomUserDetails customUserDetails);
 }

--- a/src/main/java/com/balsamic/sejongmalsami/controller/MemberControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/MemberControllerDocs.java
@@ -16,6 +16,11 @@ public interface MemberControllerDocs {
 
   @ApiChangeLogs({
       @ApiChangeLog(
+          date = "2024.10.29",
+          author = Author.SUHSAECHAN,
+          description = "엽전, 경험치 생성, Member의 isFirstLogin 전달X (JsonIgnore)"
+      ),
+      @ApiChangeLog(
           date = "2024.10.04",
           author = Author.SUHSAECHAN,
           description = "Samesite 수정: Strict -> None 크로스사이트 요청 허용"
@@ -34,56 +39,59 @@ public interface MemberControllerDocs {
   @Operation(
       summary = "로그인 요청",
       description = """
-          **로그인 요청**
-
-          세종대학교 대양휴머니티 칼리지 로그인 기능을 제공합니다.
-
-          **이 API는 인증이 필요하지 않으며, JWT 토큰 없이 접근 가능합니다**
-
-          **입력 파라미터 값:**
-
-          - **String sejongPortalId**: 세종대학교 포털 ID
-            _예: "18010561"_
-
-          - **String sejongPortalPassword**: 세종대학교 포털 비밀번호
-            _예: "your_password"_
-
-          **DB에 저장되는 학사 정보:**
-          - **String studentName**: 학생 이름
-          - **Long studentId**: 학번
-          - **String major**: 전공
-          - **String academicYear**: 학년
-          - **String enrollmentStatus**: 현재 재학 여부
-
-          **반환 파라미터 값:**
-
-          - **MemberDto**: 로그인 및 인증이 완료된 회원의 정보와 액세스 토큰
-            - **Member member**: 회원 정보
-            - **String accessToken**: JWT 액세스 토큰 (인증된 회원를 위한 토큰)
-
-          **추가로, 리프레시 토큰은 HTTP-Only 쿠키로 설정되어 반환됩니다:**
-
-          - **Set-Cookie**: `refreshToken` 쿠키가 HTTP-Only 속성으로 설정되어 전송됩니다.
-            - **Name:** `refreshToken`
-            - **Value:** JWT 리프레시 토큰
-            - **Path:** `/api/auth/refresh`
-            - **HttpOnly:** `true`
-            - **Secure:** `false` (개발 환경), `true` (배포 환경)
-            - **Max-Age:** 7일
-
-          **토큰 만료 시간:**
-
-          - **Access Token (accessToken):** 1시간
-          - **Refresh Token (refreshToken):** 7일
-
-          **참고 사항:**
-
-          - 이 API를 통해 회원은 세종대학교 포털 인증 정보를 이용하여 로그인할 수 있습니다.
-          - 성공적인 인증 후, 시스템은 액세스 토큰과 리프레시 토큰을 발급하여 반환합니다.
-          - 액세스 토큰은 클라이언트에서 인증이 필요한 API 요청 시 사용되며, 리프레시 토큰은 새로운 액세스 토큰을 발급받기 위해 서버에 저장됩니다.
-          - 리프레시 토큰은 클라이언트에서 직접 접근할 수 없도록 HTTP-Only 쿠키로 설정되어 보안이 강화됩니다.
-          - 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받는 API는 `/api/auth/refresh` 엔드포인트를 사용합니다.
-          """
+            **로그인 요청**
+            
+            세종대학교 대양휴머니티 칼리지 로그인 기능을 제공합니다.
+            
+            **이 API는 인증이 필요하지 않으며, JWT 토큰 없이 접근 가능합니다**
+            
+            **입력 파라미터 값:**
+            
+            - **String sejongPortalId**: 세종대학교 포털 ID
+              _예: "18010561"_
+            
+            - **String sejongPortalPassword**: 세종대학교 포털 비밀번호
+              _예: "your_password"_
+            
+            **DB에 저장되는 학사 정보:**
+            - **String studentName**: 학생 이름
+            - **Long studentId**: 학번
+            - **String major**: 전공
+            - **String academicYear**: 학년
+            - **String enrollmentStatus**: 현재 재학 여부
+            
+            **반환 파라미터 값:**
+            
+            - **MemberDto**: 로그인 및 인증이 완료된 회원의 정보와 토큰
+              - **Member member**: 회원 정보
+              - **String accessToken**: JWT 액세스 토큰 (인증된 회원을 위한 토큰)
+              - **Boolean isFirstLogin**: 첫 로그인 여부
+              - **Yeopjeon yeopjeon**: 엽전 정보 (첫 로그인 시 지급된 엽전)
+              - **Exp exp**: 경험치 정보
+            
+            **추가로, 리프레시 토큰은 HTTP-Only 쿠키로 설정되어 반환됩니다:**
+            
+            - **Set-Cookie**: `refreshToken` 쿠키가 HTTP-Only 속성으로 설정되어 전송됩니다.
+              - **Name:** `refreshToken`
+              - **Value:** JWT 리프레시 토큰
+              - **Path:** `/api/auth/refresh`
+              - **HttpOnly:** `true`
+              - **Secure:** `false` (개발 환경), `true` (배포 환경)
+              - **Max-Age:** 7일
+            
+            **토큰 만료 시간:**
+            
+            - **Access Token (accessToken):** 1시간
+            - **Refresh Token (refreshToken):** 7일
+            
+            **참고 사항:**
+            
+            - 이 API를 통해 회원은 세종대학교 포털 인증 정보를 이용하여 로그인할 수 있습니다.
+            - 성공적인 인증 후, 시스템은 액세스 토큰과 리프레시 토큰을 발급하여 반환합니다.
+            - 액세스 토큰은 클라이언트에서 인증이 필요한 API 요청 시 사용되며, 리프레시 토큰은 새로운 액세스 토큰을 발급받기 위해 서버에 저장됩니다.
+            - 리프레시 토큰은 클라이언트에서 직접 접근할 수 없도록 HTTP-Only 쿠키로 설정되어 보안이 강화됩니다.
+            - 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받는 API는 `/api/auth/refresh` 엔드포인트를 사용합니다.
+            """
   )
   ResponseEntity<MemberDto> signIn(
       @ModelAttribute MemberCommand command,

--- a/src/main/java/com/balsamic/sejongmalsami/object/MemberCommand.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/MemberCommand.java
@@ -1,5 +1,6 @@
 package com.balsamic.sejongmalsami.object;
 
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,7 +12,7 @@ import lombok.ToString;
 @ToString
 public class MemberCommand {
 
-  private Long memberId;
+  private UUID memberId;
   private Long studentId;
   private String studentIdString;
   private String studentName;

--- a/src/main/java/com/balsamic/sejongmalsami/object/MemberDto.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/MemberDto.java
@@ -27,4 +27,6 @@ public class MemberDto {
 
   private Yeopjeon yeopjeon;
   private Exp exp;
+
+  private Boolean isFirstLogin;
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/MemberDto.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/MemberDto.java
@@ -1,6 +1,8 @@
 package com.balsamic.sejongmalsami.object;
 
+import com.balsamic.sejongmalsami.object.postgres.Exp;
 import com.balsamic.sejongmalsami.object.postgres.Member;
+import com.balsamic.sejongmalsami.object.postgres.Yeopjeon;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -22,4 +24,7 @@ public class MemberDto {
   // token
   private String accessToken;
   private String refreshToken;
+
+  private Yeopjeon yeopjeon;
+  private Exp exp;
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/postgres/Member.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/postgres/Member.java
@@ -2,6 +2,7 @@ package com.balsamic.sejongmalsami.object.postgres;
 
 import com.balsamic.sejongmalsami.object.constants.AccountStatus;
 import com.balsamic.sejongmalsami.object.constants.Role;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -64,6 +65,7 @@ public class Member extends BaseEntity {
   private LocalDateTime lastLoginTime;
 
   @Builder.Default
+  @JsonIgnore
   private Boolean isFirstLogin = true;
 
   public void updateLastLoginTime(LocalDateTime lastLoginTime) {

--- a/src/main/java/com/balsamic/sejongmalsami/repository/postgres/ExpRepository.java
+++ b/src/main/java/com/balsamic/sejongmalsami/repository/postgres/ExpRepository.java
@@ -1,9 +1,13 @@
 package com.balsamic.sejongmalsami.repository.postgres;
 
 import com.balsamic.sejongmalsami.object.postgres.Exp;
+import com.balsamic.sejongmalsami.object.postgres.Member;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExpRepository extends JpaRepository<Exp, UUID> {
+
+  Optional<Exp> findByMember(Member member);
 
 }

--- a/src/main/java/com/balsamic/sejongmalsami/service/MemberService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/MemberService.java
@@ -80,7 +80,8 @@ public class MemberService implements UserDetailsService {
     Member member = memberRepository.findByStudentId(studentId)
         .orElseGet(() -> {
           log.info("신규 회원 등록: studentId = {}", studentId);
-          return Member.builder()
+          Member newMember = memberRepository.save(
+              Member.builder()
               .studentId(studentId)
               .studentName(dto.getStudentName())
               .uuidNickname(UUID.randomUUID().toString().substring(0, 6))
@@ -91,26 +92,43 @@ public class MemberService implements UserDetailsService {
               .role(Role.ROLE_USER)
               .accountStatus(AccountStatus.ACTIVE)
               .isFirstLogin(true)
-              .build();
+              .build());
+
+          // Exp 엔티티 생성 및 저장
+          Exp exp = expRepository.save(
+              Exp.builder()
+                  .member(newMember)
+                  .resultExp(0)
+                  .build());
+
+          log.info("신규 회원 : Exp 객체 생성 : {}", exp.getExpId());
+
+          return newMember;
         });
 
+    boolean isFirstLogin = false;
+    Yeopjeon yeopjeon = null;
+
     // 첫 로그인 여부 확인
-    if (memberRepository.existsByStudentId(studentId)) {
+    if (member.getIsFirstLogin()) {
+      isFirstLogin = true;
+
+      // 엽전 보상 지급
+      //TODO: 엽전 이력 관리 로직을 포함한 메소드 정의
+      yeopjeon = yeopjeonRepository.save(Yeopjeon.builder()
+          .member(member)
+          .resultYeopjeon(yeopjeonConfig.getCreateAccount()) // 첫 로그인 보상
+          .build());
+      log.info("첫 로그인 엽전 보상 지급: Yeopjeon ID = {}", yeopjeon.getYeopjeonId());
+
+      // 첫 로그인 플래그 비활성화
       member.disableFirstLogin();
     }
 
     // 마지막 로그인 시간 업데이트
     member.updateLastLoginTime(LocalDateTime.now());
-    log.info("회원 로그인 완료: studentId = {}", studentId);
+    log.info("회원 로그인 완료: studentId = {} , memberId = {}", studentId, member.getMemberId());
     memberRepository.save(member);
-
-    // 첫 로그인 시 엽전 테이블 생성
-    if (member.getIsFirstLogin()) {
-      yeopjeonRepository.save(Yeopjeon.builder()
-          .member(member)
-          .resultYeopjeon(yeopjeonConfig.getCreateAccount()) // 첫 로그인 보상
-          .build());
-    }
 
     // 회원 상세 정보 로드
     CustomUserDetails userDetails = new CustomUserDetails(member);
@@ -139,14 +157,14 @@ public class MemberService implements UserDetailsService {
     refreshCookie.setMaxAge((int) (jwtUtil.getRefreshExpirationTime() / 1000)); // 7일
     // SameSite 설정은 직접 Set-Cookie 헤더에 추가
 
-    // 쿠키 설정 정보 로깅
-    log.info("설정할 쿠키 정보: ");
-    log.info("Name: {}", refreshCookie.getName());
-    log.info("Value: {}", refreshCookie.getValue());
-    log.info("HttpOnly: {}", refreshCookie.isHttpOnly());
-    log.info("Secure: {}", refreshCookie.getSecure());
-    log.info("Path: {}", refreshCookie.getPath());
-    log.info("Max-Age: {}", refreshCookie.getMaxAge());
+//    // 쿠키 설정 정보 로깅
+//    log.info("설정할 쿠키 정보: ");
+//    log.info("Name: {}", refreshCookie.getName());
+//    log.info("Value: {}", refreshCookie.getValue());
+//    log.info("HttpOnly: {}", refreshCookie.isHttpOnly());
+//    log.info("Secure: {}", refreshCookie.getSecure());
+//    log.info("Path: {}", refreshCookie.getPath());
+//    log.info("Max-Age: {}", refreshCookie.getMaxAge());
 
     // 쿠키에 SameSite 속성 추가
     StringBuilder cookieBuilder = new StringBuilder();
@@ -171,8 +189,13 @@ public class MemberService implements UserDetailsService {
     return MemberDto.builder()
         .member(member)
         .accessToken(accessToken)
+        .isFirstLogin(isFirstLogin)
+        .yeopjeon(yeopjeon)
+        .exp(expRepository.findByMember(member)
+            .orElseThrow(() -> new CustomException(ErrorCode.EXP_NOT_FOUND)))
         .build();
   }
+
 
   @Transactional(readOnly = true)
   public MemberDto myPage(MemberCommand command) {

--- a/src/main/java/com/balsamic/sejongmalsami/util/config/WebSecurityConfig.java
+++ b/src/main/java/com/balsamic/sejongmalsami/util/config/WebSecurityConfig.java
@@ -81,6 +81,7 @@ public class WebSecurityConfig {
             .authorizeHttpRequests((authorize) -> authorize
                 .requestMatchers(AUTH_WHITELIST).permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/course/upload").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/api/member/my-page").hasRole("USER")
                 .anyRequest().authenticated()
             )
             .logout(logout -> logout

--- a/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
+++ b/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
@@ -135,6 +135,10 @@ public enum ErrorCode {
 
   YEOPJEON_HISTORY_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "엽전 히스토리 저장 중 오류가 발생했습니다."),
 
+  // Exp
+
+  EXP_NOT_FOUND(HttpStatus.BAD_REQUEST, "경험치 객체를 찾을 수 없습니다."),
+
   // QuestionBoardLike
 
   QUESTION_BOARD_LIKE_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "질문게시판 좋아요 내역 저장 중 오류가 발생했습니다."),


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 회원 로그인 시 Yeopjeon 및 Exp 엔티티 생성 로직 추가
- 첫 로그인 시 엽전 보상 지급 기능 구조 개선
- MemberDto 반환 값에 isFirstLogin, yeopjeon, exp 필드 추가
- 로그인 및 마이페이지 API 문서 업데이트

## ✅ 테스트
---
- [x] 수동 테스트 완료
- [ ] 테스트 코드 완료
