### PR TITLE
feat(cicd): 경로 마운트 설정

### DIFF
--- a/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
+++ b/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
@@ -110,6 +110,7 @@ jobs:
               -e TZ=Asia/Seoul \
               -e "SPRING_PROFILES_ACTIVE=prod" \
               -v /etc/localtime:/etc/localtime:ro \
+              -v /volume1/projects/sejong-malsami:/mnt/sejong-malsami \  # NAS 경로, 컨테이너 경로 마운트
               ${{ secrets.DOCKERHUB_USERNAME }}/sejong-malsami-back-container:${BRANCH}
 
             echo "배포가 성공적으로 완료되었습니다."


### PR DESCRIPTION
/mnt/sejong-malsami는 도커 컨테이너 내
 NAS의 /volume1/projects/sejong-malsami 폴더를 그대로 사용할 수 있도록 마운트된 경로
이 경로를 절대 경로로 사용하면, 컨테이너 내의 스프링 애플리케이션이 NAS의 파일에 접근하고 읽고 쓸 수 있음