### PR TITLE
feat(question): 질문 글 필터링 구현

### DIFF
--- a/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
+++ b/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
@@ -110,7 +110,7 @@ jobs:
               -e TZ=Asia/Seoul \
               -e "SPRING_PROFILES_ACTIVE=prod" \
               -v /etc/localtime:/etc/localtime:ro \
-              -v /volume1/projects/sejong-malsami:/mnt/sejong-malsami \  # NAS 경로, 컨테이너 경로 마운트
+              -v /volume1/projects/sejong-malsami:/mnt/sejong-malsami \
               ${{ secrets.DOCKERHUB_USERNAME }}/sejong-malsami-back-container:${BRANCH}
 
             echo "배포가 성공적으로 완료되었습니다."

--- a/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostController.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostController.java
@@ -55,7 +55,7 @@ public class QuestionPostController implements QuestionPostControllerDocs {
   }
 
   @Override
-  @PostMapping(value = "/get/all/no-answer", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PostMapping(value = "/get/unanswered", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitoringInvocation
   public ResponseEntity<QuestionDto> getAllQuestionPostsNotAnswered(
       @ModelAttribute QuestionCommand command) {
@@ -64,7 +64,7 @@ public class QuestionPostController implements QuestionPostControllerDocs {
   }
 
   @Override
-  @PostMapping(value = "/get/filter", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PostMapping(value = "/get/filtered-posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitoringInvocation
   public ResponseEntity<QuestionDto> getFilteredQuestionPosts(
       @ModelAttribute QuestionCommand command) {

--- a/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostController.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostController.java
@@ -64,6 +64,14 @@ public class QuestionPostController implements QuestionPostControllerDocs {
   }
 
   @Override
+  @PostMapping(value = "/get/filter", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @LogMonitoringInvocation
+  public ResponseEntity<QuestionDto> getFilteredQuestionPosts(
+      @ModelAttribute QuestionCommand command) {
+    return ResponseEntity.ok(questionPostService.filteredQuestions(command));
+  }
+
+  @Override
   @PostMapping(value = "/popular/daily", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @LogMonitoringInvocation
   public ResponseEntity<QuestionDto> getDailyPopularQuestionPost(

--- a/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
@@ -108,9 +108,9 @@ public interface QuestionPostControllerDocs {
       )
   })
   @Operation(
-      summary = "질문 글 조회",
+      summary = "특정 질문 글 조회",
       description = """
-          **질문 글 조회 요청**
+          **특정 질문 글 조회 요청**
 
           **이 API는 인증이 필요하며, JWT 토큰이 존재해야합니다.**
 
@@ -128,6 +128,7 @@ public interface QuestionPostControllerDocs {
           **참고 사항:**
 
           - 이 API를 통해 사용자는 postId 값에 해당하는 질문 글을 조회할 수 있습니다.
+          - 반환된 질문글의 조회수가 1 증가합니다.
           - Swagger에서 테스트 시 mediaFiles에 있는 "Send empty value" 체크박스 해제해야합니다.
           """
   )

--- a/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
@@ -182,19 +182,26 @@ public interface QuestionPostControllerDocs {
 
   @ApiChangeLogs({
       @ApiChangeLog(
+          date = "2024.11.6",
+          author = Author.BAEKJIHOON,
+          description = "단과대 필터링 추가"
+      ),
+      @ApiChangeLog(
           date = "2024.11.1",
           author = Author.BAEKJIHOON,
           description = "답변 개수가 0개인 글 조회"
       )
   })
   @Operation(
-      summary = "답변 개수가 0개인 글 조회 (최신순)",
+      summary = "답변 개수가 0개인 글 조회 및 단과대 필터링 (최신순)",
       description = """
           **답변 개수가 0개인 질문 글 조회 요청**
 
           **이 API는 인증이 필요하며, JWT 토큰이 존재해야합니다.**
 
           **입력 파라미터 값:**
+          
+          - **Faculty faculty**: 단과대 필터링 [선택]
 
           - **Integer pageNumber**: 조회하고싶은 페이지 번호 [선택] (default = 0)
            
@@ -203,11 +210,12 @@ public interface QuestionPostControllerDocs {
           **반환 파라미터 값:**
 
           - **QuestionDto**: 질문 게시판 정보 반환
-            - **Page\\<QuestionPost\\> questionPosts**: 답변 개수가 0개인 질문글 리스트
+            - **Page\\<QuestionPost\\> questionPosts**: 단과대 필터링이 적용 된 답변 개수가 0개인 질문글 리스트
 
           **참고 사항:**
 
           - 이 API를 통해 사용자는 아직 답변이 작성되지 않은 질문 글 최신순으로 조회할 수 있습니다.
+          - 단과대 필터링 적용 시 해당 단과대가 적용된 글 중 답변 개수가 0개인 질문글을 반환합니다.
           - Swagger에서 테스트 시 mediaFiles에 있는 "Send empty value" 체크박스 해제해야합니다.
           - pageNumber = 3, pageSize = 10 입력시 4페이지에 해당하는 10개의 글을 반환합니다. (31번째 글 ~ 40번째 글 반환)
           """

--- a/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/QuestionPostControllerDocs.java
@@ -218,6 +218,80 @@ public interface QuestionPostControllerDocs {
 
   @ApiChangeLogs({
       @ApiChangeLog(
+          date = "2024.11.6",
+          author = Author.BAEKJIHOON,
+          description = "파라미터 수정"
+      ),
+      @ApiChangeLog(
+          date = "2024.11.4",
+          author = Author.BAEKJIHOON,
+          description = "질문 글 필터링 init"
+      )
+  })
+  @Operation(
+      summary = "질문 글 필터링 조회",
+      description = """
+          **질문 글 필터링 조회 요청**
+
+          **이 API는 인증이 필요하며, JWT 토큰이 존재해야합니다.**
+
+          **입력 파라미터 값:**
+          
+          - **String subject**: 교과목명 필터링 [선택]
+          
+          - **Integer minYeopjeon**: 엽전 현상금 최소 개수 [선택]
+          
+          - **Integer maxYeopjeon**: 엽전 현상금 최대 개수 [선택]
+          
+          - **Set<QuestionPresetTag> questionPresetTagSet**: 정적 태그 필터링 [선택]
+          
+          - **Faculty faculty**: 단과대별 필터링 [선택]
+          
+          - **Boolean viewNotChaetaek**: 아직 채택되지 않은 글 필터링 [선택] (default = false)
+          
+          - **SortType sortType**: 정렬 조건 [선택]
+          
+          - **Integer pageNumber**: 조회하고싶은 페이지 번호 [선택] (default = 0)
+           
+          - **Integer pageSize**: 한 페이지에 조회하고싶은 글 개수 [선택] (default = 30)
+          
+
+          **반환 파라미터 값:**
+
+          - **QuestionDto**: 질문 게시판 정보 반환
+            - **Page\\<QuestionPost\\> questionPosts**: 필터링 된 질문글 리스트
+          
+          **정적 태그**
+           
+          *총 7개의 정적태그가 존재하며 최대 2개까지의 정적태그를 설정할 수 있습니다.*
+          - **OUT_OF_CLASS** (수업 외 내용)
+          - **UNKNOWN_CONCEPT** (개념 모름)
+          - **BETTER_SOLUTION** (더 나은 풀이)
+          - **EXAM_PREPARATION** (시험 대비)
+          - **DOCUMENT_REQUEST** (자료 요청)
+          - **STUDY_TIPS** (공부 팁)
+          - **ADVICE_REQUEST** (조언 구함)
+          
+          **정렬 타입**
+          
+          - **LATEST** (최신순)
+          - **MOST_LIKED** (좋아요순)
+          - **YEOPJEON_REWARD** (엽전 현상금 순)
+          - **VIEW_COUNT** (조회수 순)
+
+          **참고 사항:**
+
+          - 이 API를 통해 사용자는 질문 게시판에 작성된 글을 필터링하여 조회할 수 있습니다.
+          - Swagger에서 테스트 시 mediaFiles에 있는 "Send empty value" 체크박스 해제해야합니다.
+          - pageNumber = 3, pageSize = 10 입력시 4페이지에 해당하는 10개의 글을 반환합니다. (31번째 글 ~ 40번째 글 반환)
+          """
+  )
+  ResponseEntity<QuestionDto> getFilteredQuestionPosts(
+      QuestionCommand command
+  );
+
+  @ApiChangeLogs({
+      @ApiChangeLog(
           date = "2024.11.1",
           author = Author.BAEKJIHOON,
           description = "Page<QuestionPost> 반환값 수정"

--- a/src/main/java/com/balsamic/sejongmalsami/object/QuestionCommand.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/QuestionCommand.java
@@ -1,10 +1,11 @@
 package com.balsamic.sejongmalsami.object;
 
 import com.balsamic.sejongmalsami.object.constants.ContentType;
+import com.balsamic.sejongmalsami.object.constants.Faculty;
 import com.balsamic.sejongmalsami.object.constants.QuestionPresetTag;
+import com.balsamic.sejongmalsami.object.constants.SortType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,16 +26,20 @@ public class QuestionCommand {
   private String content; // 질문, 답변
   private String subject; // 질문
   private List<MultipartFile> mediaFiles; // 질문, 답변
-  private Set<QuestionPresetTag> questionPresetTagSet; // 질문
-  private Set<String> customTagSet; // 질문
+  private List<QuestionPresetTag> questionPresetTags; // 질문
+  private List<String> customTagSet; // 질문
   private Integer rewardYeopjeon; // 질문
   private ContentType contentType;
-  private Boolean isChaetaek; // 답변
   private Boolean isPrivate; // 질문, 답변
   @Schema(defaultValue = "0")
   private Integer pageNumber = 0; // n번째 페이지 조회
   @Schema(defaultValue = "30")
   private Integer pageSize = 30; // n개의 데이터 조회
 
-
+  // 핕터링 파라미터
+  private Faculty faculty; // 단과대별 조회 (필터링)
+  private Integer minYeopjeon; // 최소 엽전 (필터링)
+  private Integer maxYeopjeon; // 최대 엽전 (필터링)
+  private SortType sortType; // 정렬 타입 (최신순, 좋아요순, 엽전현상금순, 조회순)
+  private Boolean viewNotChaetaek; // 채택 안된 글
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/QuestionDto.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/QuestionDto.java
@@ -17,7 +17,7 @@ public class QuestionDto {
 
   private QuestionPost questionPost; // 질문
 
-  private Page<QuestionPost> questionPosts; // 질문
+  private Page<QuestionPost> questionPostsPage; // 질문
 
   private AnswerPost answerPost; // 답변
 

--- a/src/main/java/com/balsamic/sejongmalsami/object/QuestionDto.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/QuestionDto.java
@@ -5,7 +5,6 @@ import com.balsamic.sejongmalsami.object.postgres.AnswerPost;
 import com.balsamic.sejongmalsami.object.postgres.MediaFile;
 import com.balsamic.sejongmalsami.object.postgres.QuestionPost;
 import java.util.List;
-import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -28,7 +27,7 @@ public class QuestionDto {
   private List<MediaFile> mediaFiles; // 질문, 답변
 
   // 커스텀 태그
-  private Set<String> customTags; // 질문
+  private List<String> customTags; // 질문
 
   // 좋아요 내역
   private QuestionBoardLike questionBoardLike;

--- a/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum SortType {
-  LATEST("최신 순"),
-  MOST_LIKED("좋아요 순"),
-  YEOPJEON_REWARD("엽전 현상금 순"),
-  VIEW_COUNT("조회수 순");
+  LATEST("최신순"),
+  MOST_LIKED("추천순"),
+  YEOPJEON_REWARD("엽전 현상금 높은 순"),
+  VIEW_COUNT("조회수 많은순");
 
   private final String description;
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
@@ -1,0 +1,15 @@
+package com.balsamic.sejongmalsami.object.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SortType {
+  LATEST("최신 순"),
+  MOST_LIKED("좋아요 순"),
+  YEOPJEON_REWARD("엽전 현상금 순"),
+  VIEW_COUNT("조회수 순");
+
+  private final String description;
+}

--- a/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/constants/SortType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum SortType {
   LATEST("최신순"),
   MOST_LIKED("추천순"),
-  YEOPJEON_REWARD("엽전 현상금 높은 순"),
+  YEOPJEON_REWARD("엽전 현상금 높은순"),
   VIEW_COUNT("조회수 많은순");
 
   private final String description;

--- a/src/main/java/com/balsamic/sejongmalsami/object/postgres/QuestionPost.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/postgres/QuestionPost.java
@@ -62,6 +62,7 @@ public class QuestionPost extends BasePost {
   @ElementCollection(targetClass = Faculty.class, fetch = FetchType.LAZY)
   @Enumerated(EnumType.STRING)
   @CollectionTable(name = "question_faculties", joinColumns = @JoinColumn(name = "question_post_id"))
+  @Builder.Default
   @Column
   private List<Faculty> faculties = new ArrayList<>();
 
@@ -69,8 +70,8 @@ public class QuestionPost extends BasePost {
   @ElementCollection(targetClass = QuestionPresetTag.class, fetch = FetchType.LAZY)
   @Enumerated(EnumType.STRING)
   @CollectionTable(name = "question_preset_tags", joinColumns = @JoinColumn(name = "question_post_id"))
-  @Column
   @Builder.Default
+  @Column
   private List<QuestionPresetTag> questionPresetTags = new ArrayList<>();
 
   // 조회 수
@@ -96,6 +97,11 @@ public class QuestionPost extends BasePost {
   // 내 정보 비공개 여부
   @Builder.Default
   private Boolean isPrivate = false;
+
+  // 조회 수 증가
+  public void increaseViewCount() {
+    viewCount++;
+  }
 
   // 좋아요 증가
   public void increaseLikeCount() {

--- a/src/main/java/com/balsamic/sejongmalsami/object/postgres/QuestionPost.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/postgres/QuestionPost.java
@@ -5,7 +5,9 @@ import com.balsamic.sejongmalsami.object.constants.QuestionPresetTag;
 import com.balsamic.sejongmalsami.util.exception.CustomException;
 import com.balsamic.sejongmalsami.util.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,10 +15,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,12 +59,19 @@ public class QuestionPost extends BasePost {
   private String subject;
 
   // 단과대
-  private List<Faculty> faculties;
+  @ElementCollection(targetClass = Faculty.class, fetch = FetchType.LAZY)
+  @Enumerated(EnumType.STRING)
+  @CollectionTable(name = "question_faculties", joinColumns = @JoinColumn(name = "question_post_id"))
+  @Column
+  private List<Faculty> faculties = new ArrayList<>();
 
   // 정적 태그
-  @Builder.Default
+  @ElementCollection(targetClass = QuestionPresetTag.class, fetch = FetchType.LAZY)
   @Enumerated(EnumType.STRING)
-  private Set<QuestionPresetTag> questionPresetTagSet = new HashSet<>();
+  @CollectionTable(name = "question_preset_tags", joinColumns = @JoinColumn(name = "question_post_id"))
+  @Column
+  @Builder.Default
+  private List<QuestionPresetTag> questionPresetTags = new ArrayList<>();
 
   // 조회 수
   @Builder.Default
@@ -104,12 +113,12 @@ public class QuestionPost extends BasePost {
   // 질문글 정적 태그 추가(최대 2개)
   public void addPresetTag(QuestionPresetTag tag) {
 
-    if (questionPresetTagSet.size() >= MAX_PRESET_TAGS) {
+    if (questionPresetTags.size() >= MAX_PRESET_TAGS) {
       throw new CustomException(ErrorCode.QUESTION_PRESET_TAG_LIMIT_EXCEEDED);
     }
 
     // 태그 추가
-    questionPresetTagSet.add(tag);
+    questionPresetTags.add(tag);
   }
 
   // 답변 수 동기화

--- a/src/main/java/com/balsamic/sejongmalsami/repository/postgres/QuestionPostRepository.java
+++ b/src/main/java/com/balsamic/sejongmalsami/repository/postgres/QuestionPostRepository.java
@@ -32,8 +32,16 @@ public interface QuestionPostRepository extends JpaRepository<QuestionPost, UUID
   // 주간 인기글 상위 n개 조회 (7일 이내에 등록된 글만 조회)
   List<QuestionPost> findTop50ByCreatedDateAfterOrderByWeeklyScoreDesc(LocalDateTime lastWeek);
 
-  // 아직 답변하지 않은 질문글 조회 (최신순)
-  Page<QuestionPost> findByAnswerCount(int answerCount, Pageable pageable);
+  // 아직 답변하지 않은 질문글 조회 및 단과대 필터링 (최신순)
+  @Query("""
+      select q
+      from QuestionPost q
+      where (:faculty is null or :faculty member of q.faculties)
+      and (q.answerCount = 0)
+      """)
+  Page<QuestionPost> findFilteredNotAnsweredQuestion(
+      @Param("faculty") Faculty faculty,
+      Pageable pageable);
 
   // 과목 필터링
   @Query("""

--- a/src/main/java/com/balsamic/sejongmalsami/service/PopularPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/PopularPostService.java
@@ -139,7 +139,7 @@ public class PopularPostService {
     Page<QuestionPost> posts = new PageImpl<>(subList, pageable, cachedPosts.size());
 
     return QuestionDto.builder()
-        .questionPosts(posts)
+        .questionPostsPage(posts)
         .build();
   }
 
@@ -169,7 +169,7 @@ public class PopularPostService {
     Page<QuestionPost> posts = new PageImpl<>(subList, pageable, cachedPosts.size());
 
     return QuestionDto.builder()
-        .questionPosts(posts)
+        .questionPostsPage(posts)
         .build();
   }
 

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostCustomTagService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostCustomTagService.java
@@ -4,9 +4,8 @@ import com.balsamic.sejongmalsami.object.mongo.QuestionPostCustomTag;
 import com.balsamic.sejongmalsami.repository.mongo.QuestionPostCustomTagRepository;
 import com.balsamic.sejongmalsami.util.exception.CustomException;
 import com.balsamic.sejongmalsami.util.exception.ErrorCode;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,7 +23,7 @@ public class QuestionPostCustomTagService {
 
   // 커스텀 태그 저장 로직
   @Transactional
-  public Set<String> saveCustomTags(Set<String> customTags, UUID postId) {
+  public List<String> saveCustomTags(List<String> customTags, UUID postId) {
 
     // 커스텀 태그는 4개까지만 추가가능
     if (customTags.size() > CUSTOM_TAG_LIMIT) {
@@ -45,6 +44,6 @@ public class QuestionPostCustomTagService {
                 .customTag(tag)
                 .build()
         ).getCustomTag()) // 저장 후 태그 반환
-        .collect(Collectors.toSet());
+        .toList();
   }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
@@ -110,12 +110,17 @@ public class QuestionPostService {
         .build();
   }
 
-  /* 특정 질문 글 조회 로직 */
-  @Transactional(readOnly = true)
+  /* 특정 질문 글 조회 로직 (해당 글 조회 수 증가) */
+  @Transactional
   public QuestionDto findQuestionPost(QuestionCommand command) {
+
+    QuestionPost questionPost = questionPostRepository.findById(command.getPostId())
+        .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_POST_NOT_FOUND));
+    questionPost.increaseViewCount();
+    log.info("제목: {}, 조회수: {}", questionPost.getTitle(), questionPost.getViewCount());
+
     return QuestionDto.builder()
-        .questionPost(questionPostRepository.findById(command.getPostId())
-            .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_POST_NOT_FOUND)))
+        .questionPost(questionPostRepository.save(questionPost))
         .build();
   }
 
@@ -137,7 +142,7 @@ public class QuestionPostService {
     Page<QuestionPost> posts = questionPostRepository.findAll(pageable);
 
     return QuestionDto.builder()
-        .questionPosts(posts)
+        .questionPostsPage(posts)
         .build();
   }
 
@@ -161,7 +166,7 @@ public class QuestionPostService {
         .findFilteredNotAnsweredQuestion(command.getFaculty(), pageable);
 
     return QuestionDto.builder()
-        .questionPosts(postPage)
+        .questionPostsPage(postPage)
         .build();
   }
 
@@ -232,7 +237,7 @@ public class QuestionPostService {
     log.info("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
     return QuestionDto.builder()
-        .questionPosts(posts)
+        .questionPostsPage(posts)
         .build();
   }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
@@ -170,6 +170,7 @@ public class QuestionPostService {
    * <p>2. 엽전 현상금 범위 필터링 - Integer minYeopjeon, Integer maxYeopjeon
    * <p>3. 정적 태그 필터링 - QuestionPresetTag (최대 2개)
    * <p>4. 단과대별 필터링 - Faculty (ex. 공과대학, 예체는대학)
+   * <p>5. 아직 채택되지 않은 질문 글 필터링 - Boolean viewNotChaetaek
    * <br><br>
    * <h3>정렬 로직 (SortType)
    * <p>최신순, 좋아요순, 엽전 현상금순, 조회순

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
@@ -142,10 +142,11 @@ public class QuestionPostService {
   }
 
   /**
-   * 아직 답변 안된 글 조회 로직 (최신순)
-   * @param command <br>
-   * Integer pageNumber <br>
-   * Integer pageSize <br>
+   * 아직 답변 안된 글 조회 로직 + 단과대 필터링 (정렬: 최신순)
+   * @param command
+   * <p>Faculty faculty
+   * <p>Integer pageNumber
+   * <p>Integer pageSize
    *
    * @return
    */
@@ -157,7 +158,7 @@ public class QuestionPostService {
         Sort.by("createdDate").descending());
 
     Page<QuestionPost> postPage = questionPostRepository
-        .findByAnswerCount(0, pageable);
+        .findFilteredNotAnsweredQuestion(command.getFaculty(), pageable);
 
     return QuestionDto.builder()
         .questionPosts(postPage)

--- a/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
+++ b/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
@@ -79,6 +79,8 @@ public enum ErrorCode {
 
   // Course
 
+  FACULTY_NOT_FOUND(HttpStatus.BAD_REQUEST, "교과목명에 해당하는 단과대를 찾을 수 없습니다."),
+
   COURSE_SAVE_ERROR(HttpStatus.BAD_REQUEST, "교과목명 파일 처리 중 오류가 발생했습니다"),
 
   WRONG_FACULTY_NAME(HttpStatus.BAD_REQUEST, "올바르지 않은 단과 대학입니다"),


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
질문글 필터링 구현
1. 교과목명 기준 필터링
2. 엽전 현상금 범위 필터링
3. 정적 태그 필터링 (최대2개 선택가능)
4. 단과대별 필터링
5. 채택되지 않은 질문글 필터링

정렬로직
* 최신순, 추천순, 엽전 현상금 순, 조회순

정적 태그 같은경우 1개를 선택하면 해당 태그가 포함된 모든 질문글이 반환됩니다.
2개 선택시 해당 태그가 완벽하게 적용된 질문글이 아닌, 둘 중 하나라도 포함하고있는 질문글을 모두 반환합니다.
정적 태그들이 성격이 독립성이 강한 느낌이라 사용자들이 태그 2개가 완벽하게 적용된 질문글을 찾는일이 거의 없을 듯하여 이런 형태로 코드를 작성했습니다.

## ✅ 테스트
---
- [x] 수동 테스트 완료
- [x] 테스트 코드 완료
