### PR TITLE
refactor(yeopjeon): 엽전 로직 개선

### DIFF
--- a/src/main/java/com/balsamic/sejongmalsami/controller/DocumentPostController.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/DocumentPostController.java
@@ -73,4 +73,12 @@ public class DocumentPostController implements DocumentPostControllerDocs {
     command.setMemberId(customUserDetails.getMemberId());
     return ResponseEntity.ok(documentPostService.filteredDocumentPost(command));
   }
+
+  @Override
+  public ResponseEntity<DocumentDto> downloadDocumentFile(
+      CustomUserDetails customUserDetails,
+      DocumentCommand command) {
+    command.setMember(customUserDetails.getMember());
+    return ResponseEntity.ok(documentPostService.downloadDocumentFile(command));
+  }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/controller/DocumentPostControllerDocs.java
+++ b/src/main/java/com/balsamic/sejongmalsami/controller/DocumentPostControllerDocs.java
@@ -298,4 +298,32 @@ public interface DocumentPostControllerDocs {
   ResponseEntity<DocumentDto> filteredDocumentPost(
       CustomUserDetails customUserDetails,
       DocumentCommand command);
+
+
+  @ApiChangeLogs({
+      @ApiChangeLog(
+          date = "2024.11.30",
+          author = Author.SUHSAECHAN,
+          description = ""
+      )
+  })
+  @Operation(
+      summary = "자료게시판 자료 다운",
+      description = """
+        **자료게시판 자료 다운**
+
+        **이 API는 인증이 필요하며, JWT 토큰이 존재해야 합니다**
+
+        ### **요청 파라미터**
+        - **`String filePath`** : 파일 경로
+
+        ### **반환 파라미터 값**
+
+        - **`MemberDto`**: 회원의 상세 정보 및 통계
+          - **`Member member`** : 회원 정보
+        """
+  )
+  ResponseEntity<DocumentDto> downloadDocumentFile(
+      CustomUserDetails customUserDetails,
+      DocumentCommand command);
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/DocumentCommand.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/DocumentCommand.java
@@ -52,4 +52,7 @@ public class DocumentCommand {
   private ReactionType reactionType; // 글 좋아요/싫어요
   private SortType sortType; // 최신순, 좋아요순
   private PostTier postTier;
+
+  private String filePath;
+  private UUID documentFileId;
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/mongo/PurchaseHistory.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/mongo/PurchaseHistory.java
@@ -1,7 +1,9 @@
 package com.balsamic.sejongmalsami.object.mongo;
 
+import com.balsamic.sejongmalsami.object.postgres.DocumentFile;
+import com.balsamic.sejongmalsami.object.postgres.DocumentPost;
+import com.balsamic.sejongmalsami.object.postgres.Member;
 import jakarta.validation.constraints.NotNull;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,19 +24,15 @@ public class PurchaseHistory extends BaseMongoEntity {
 
   @Indexed
   @NotNull
-  private UUID memberId;
+  private Member member;
 
   @Indexed
   @NotNull
-  private UUID documentPostId;
+  private DocumentPost documentPost;
 
   @Indexed
   @NotNull
-  private UUID DocumentFileId;
+  private DocumentFile documentFile;
 
-  @NotNull
-  private Integer yeopjeonSpent; // 소모한 엽전양
-
-  @NotNull
-  private Integer resultYeopjeon;   // 남은 엽전양
+  private YeopjeonHistory yeopjeonHistory;
 }

--- a/src/main/java/com/balsamic/sejongmalsami/object/postgres/Yeopjeon.java
+++ b/src/main/java/com/balsamic/sejongmalsami/object/postgres/Yeopjeon.java
@@ -11,10 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -31,8 +33,4 @@ public class Yeopjeon {
 
   // 총 엽전량
   private Integer yeopjeon;
-
-  public void updateYeopjeon(int yeopjeon) {
-    this.yeopjeon = yeopjeon;
-  }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/service/AnswerPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/AnswerPostService.java
@@ -157,8 +157,7 @@ public class AnswerPostService {
 
     YeopjeonHistory curMemberYeopjeonHistory = null;
     try { // 로그인 사용자 엽전 변동 및 엽전 히스토리 저장 - B
-      curMemberYeopjeonHistory = yeopjeonService
-          .processYeopjeon(curMember, YeopjeonAction.CHAETAEK_ACCEPT);
+      curMemberYeopjeonHistory = yeopjeonService.processYeopjeon(curMember, YeopjeonAction.CHAETAEK_ACCEPT);
     } catch (Exception e) { // B 실패시 A 롤백
       yeopjeonService.rollbackYeopjeonTransaction(
           answerMember,

--- a/src/main/java/com/balsamic/sejongmalsami/service/AnswerPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/AnswerPostService.java
@@ -153,14 +153,14 @@ public class AnswerPostService {
 
     // 답변 작성자 엽전 변동 및 엽전 히스토리 저장 - A
     YeopjeonHistory answerMemberYeopjeonHistory = yeopjeonService
-        .updateYeopjeonAndSaveYeopjeonHistory(answerMember, YeopjeonAction.CHAETAEK_CHOSEN);
+        .processYeopjeon(answerMember, YeopjeonAction.CHAETAEK_CHOSEN);
 
     YeopjeonHistory curMemberYeopjeonHistory = null;
     try { // 로그인 사용자 엽전 변동 및 엽전 히스토리 저장 - B
       curMemberYeopjeonHistory = yeopjeonService
-          .updateYeopjeonAndSaveYeopjeonHistory(curMember, YeopjeonAction.CHAETAEK_ACCEPT);
+          .processYeopjeon(curMember, YeopjeonAction.CHAETAEK_ACCEPT);
     } catch (Exception e) { // B 실패시 A 롤백
-      yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+      yeopjeonService.rollbackYeopjeonTransaction(
           answerMember,
           YeopjeonAction.CHAETAEK_CHOSEN,
           answerMemberYeopjeonHistory
@@ -173,12 +173,12 @@ public class AnswerPostService {
       answerMemberExpHistory = expService
           .updateExpAndSaveExpHistory(answerMember, ExpAction.CHAETAEK_CHOSEN);
     } catch (Exception e) { // C 실패시 A, B 롤백
-      yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+      yeopjeonService.rollbackYeopjeonTransaction(
           curMember,
           YeopjeonAction.CHAETAEK_ACCEPT,
           curMemberYeopjeonHistory
       );
-      yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+      yeopjeonService.rollbackYeopjeonTransaction(
           answerMember,
           YeopjeonAction.CHAETAEK_CHOSEN,
           answerMemberYeopjeonHistory
@@ -193,12 +193,12 @@ public class AnswerPostService {
           ExpAction.CHAETAEK_CHOSEN,
           answerMemberExpHistory
       );
-      yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+      yeopjeonService.rollbackYeopjeonTransaction(
           curMember,
           YeopjeonAction.CHAETAEK_ACCEPT,
           curMemberYeopjeonHistory
       );
-      yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+      yeopjeonService.rollbackYeopjeonTransaction(
           answerMember,
           YeopjeonAction.CHAETAEK_CHOSEN,
           answerMemberYeopjeonHistory
@@ -219,7 +219,7 @@ public class AnswerPostService {
           answerMember.getStudentId(), answerMemberYeopjeon.getYeopjeon());
 
       try { // 답변 작성자 엽전 변동 및 엽전 히스토리 저장 - E
-        yeopjeonService.updateYeopjeonAndSaveYeopjeonHistory(
+        yeopjeonService.processYeopjeon(
             answerMember,
             YeopjeonAction.REWARD_YEOPJEON,
             questionPost.getRewardYeopjeon());
@@ -235,12 +235,12 @@ public class AnswerPostService {
             ExpAction.CHAETAEK_CHOSEN,
             answerMemberExpHistory
         );
-        yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+        yeopjeonService.rollbackYeopjeonTransaction(
             curMember,
             YeopjeonAction.CHAETAEK_ACCEPT,
             curMemberYeopjeonHistory
         );
-        yeopjeonService.rollbackYeopjeonAndDeleteYeopjeonHistory(
+        yeopjeonService.rollbackYeopjeonTransaction(
             answerMember,
             YeopjeonAction.CHAETAEK_CHOSEN,
             answerMemberYeopjeonHistory

--- a/src/main/java/com/balsamic/sejongmalsami/service/DocumentPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/DocumentPostService.java
@@ -25,6 +25,7 @@ import com.balsamic.sejongmalsami.repository.mongo.DocumentBoardLikeRepository;
 import com.balsamic.sejongmalsami.repository.postgres.CourseRepository;
 import com.balsamic.sejongmalsami.repository.postgres.DocumentPostRepository;
 import com.balsamic.sejongmalsami.repository.postgres.MemberRepository;
+import com.balsamic.sejongmalsami.repository.postgres.YeopjeonRepository;
 import com.balsamic.sejongmalsami.util.config.YeopjeonConfig;
 import com.balsamic.sejongmalsami.util.exception.CustomException;
 import com.balsamic.sejongmalsami.util.exception.ErrorCode;
@@ -57,6 +58,7 @@ public class DocumentPostService {
   private final CourseRepository courseRepository;
   private final YeopjeonService yeopjeonService;
   private final YeopjeonConfig yeopjeonConfig;
+  private final YeopjeonRepository yeopjeonRepository;
 
   /**
    * <h3>자료 글 저장
@@ -242,13 +244,13 @@ public class DocumentPostService {
     // 게시글 등급에 따라 사용자 엽전 변동 및 엽전 히스토리 저장
     switch (postTier) {
       case CHEONMIN -> yeopjeonService
-          .updateYeopjeonAndSaveYeopjeonHistory(member, VIEW_DOCUMENT_CHEONMIN_POST);
+          .processYeopjeon(member, VIEW_DOCUMENT_CHEONMIN_POST);
       case JUNGIN -> yeopjeonService
-          .updateYeopjeonAndSaveYeopjeonHistory(member, VIEW_DOCUMENT_JUNGIN_POST);
+          .processYeopjeon(member, VIEW_DOCUMENT_JUNGIN_POST);
       case YANGBAN -> yeopjeonService
-          .updateYeopjeonAndSaveYeopjeonHistory(member, VIEW_DOCUMENT_YANGBAN_POST);
+          .processYeopjeon(member, VIEW_DOCUMENT_YANGBAN_POST);
       case KING -> yeopjeonService
-          .updateYeopjeonAndSaveYeopjeonHistory(member, VIEW_DOCUMENT_KING_POST);
+          .processYeopjeon(member, VIEW_DOCUMENT_KING_POST);
     }
 
     // 해당 자료 글 조회수 증가
@@ -293,5 +295,16 @@ public class DocumentPostService {
     } else {
       throw new CustomException(ErrorCode.INVALID_POST_TIER);
     }
+  }
+
+  // 파일 다운로드
+  public DocumentDto downloadDocumentFile(DocumentCommand command) {
+    Member member = command.getMember();
+
+    // 엽전
+    Yeopjeon yeopjeon = yeopjeonRepository.findByMember(member)
+        .orElseThrow(() -> new CustomException(ErrorCode.YEOPJEON_NOT_FOUND));
+
+    return null;
   }
 }

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
@@ -91,7 +91,7 @@ public class QuestionPostService {
       throw new CustomException(ErrorCode.INSUFFICIENT_YEOPJEON);
     }
     // 질문글 작성자가 등록한 엽전 현상금 만큼 엽전 수 감소
-    yeopjeonService.updateYeopjeonAndSaveYeopjeonHistory(
+    yeopjeonService.processYeopjeon(
         member,
         YeopjeonAction.REWARD_YEOPJEON,
         -command.getRewardYeopjeon());
@@ -156,7 +156,7 @@ public class QuestionPostService {
     }
 
     // 질문 글 등록 시 엽전 100냥 감소
-    yeopjeonService.updateYeopjeonAndSaveYeopjeonHistory(member, YeopjeonAction.CREATE_QUESTION_POST);
+    yeopjeonService.processYeopjeon(member, YeopjeonAction.CREATE_QUESTION_POST);
 
     // 질문 글 등록 시 경험치 증가
     expService.updateExpAndSaveExpHistory(member, ExpAction.CREATE_QUESTION_POST);

--- a/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/QuestionPostService.java
@@ -81,13 +81,9 @@ public class QuestionPostService {
 
     // {질문글 등록 시 소모엽전 + 엽전 현상금} 보다 보유 엽전량이 적을 시 오류 발생
     Yeopjeon yeopjeon = yeopjeonService.findMemberYeopjeon(member);
-    if (yeopjeon.getYeopjeon() < command.getRewardYeopjeon()
-                                 + -yeopjeonCalculator.calculateYeopjeon(YeopjeonAction.CREATE_QUESTION_POST)) {
+    if (yeopjeon.getYeopjeon() < command.getRewardYeopjeon() + -yeopjeonCalculator.calculateYeopjeon(YeopjeonAction.CREATE_QUESTION_POST)) {
       log.error("사용자: {} 의 엽전이 부족합니다.", member.getStudentId());
-      log.error("현재 보유 엽전량: {}, 질문글 등록시 필요 엽전량: {}, 엽전 현상금 설정량: {}",
-          yeopjeon.getYeopjeon(),
-          -yeopjeonCalculator.calculateYeopjeon(YeopjeonAction.CREATE_QUESTION_POST),
-          command.getRewardYeopjeon());
+      log.error("현재 보유 엽전량: {}, 질문글 등록시 필요 엽전량: {}, 엽전 현상금 설정량: {}", yeopjeon.getYeopjeon(), -yeopjeonCalculator.calculateYeopjeon(YeopjeonAction.CREATE_QUESTION_POST), command.getRewardYeopjeon());
       throw new CustomException(ErrorCode.INSUFFICIENT_YEOPJEON);
     }
     // 질문글 작성자가 등록한 엽전 현상금 만큼 엽전 수 감소

--- a/src/main/java/com/balsamic/sejongmalsami/service/YeopjeonService.java
+++ b/src/main/java/com/balsamic/sejongmalsami/service/YeopjeonService.java
@@ -24,86 +24,43 @@ public class YeopjeonService {
   private final YeopjeonHistoryService yeopjeonHistoryService;
   private final MemberRepository memberRepository;
 
-  // 엽전 변동 로직 및 엽전 히스토리 내역 저장 (롤백 포함)
+  // 엽전 처리 수행 메인 메서드 (엽전현상금 없음)
+  public YeopjeonHistory processYeopjeon(Member member, YeopjeonAction action) {
+    return processYeopjeon(member, action, 0);
+  }
+
+  // 엽전 처리 수행 메인 메서드 (엽전현상금 포함)
   @Transactional
-  public YeopjeonHistory updateYeopjeonAndSaveYeopjeonHistory(Member member, YeopjeonAction action) {
+  public YeopjeonHistory processYeopjeon(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
+
+    // rewardYeopjeon 기본값 처리
+    rewardYeopjeon = (rewardYeopjeon != null) ? rewardYeopjeon : 0;
+
+    // 엽전 계산 및 검증
+    int newYeopjeon = calculateAndValidateYeopjeon(member, action, rewardYeopjeon);
+
+    // 엽전 변동 적용
+    applyYeopjeonChanges(member, newYeopjeon);
+
+    // 엽전 히스토리 저장
     YeopjeonHistory yeopjeonHistory;
-
-    updateMemberYeopjeon(member, action, null);
-
     try {
       yeopjeonHistory = yeopjeonHistoryService.saveYeopjeonHistory(member, action);
       log.info("회원: {} 엽전 히스토리 저장 성공", member.getStudentId());
     } catch (Exception e) {
-      log.error("회원: {} 엽전 히스토리 저장 시 오류가 발생했습니다. 오류내용: {}", member.getStudentId(), e.getMessage());
-      log.info("회원: {} 엽전 롤백을 진행합니다.", member.getStudentId());
-      rollbackYeopjeon(member, action, null);
+      log.error("회원: {} 엽전 히스토리 저장 중 오류 발생: {}", member.getStudentId(), e.getMessage());
+      revertYeopjeonChange(member, action, rewardYeopjeon);
       throw new CustomException(ErrorCode.YEOPJEON_SAVE_ERROR);
     }
 
     return yeopjeonHistory;
   }
 
-  // 엽전 변동 로직 및 엽전 히스토리 내역 저장 (엽전 현상금 커스텀 가능한 경우)
-  @Transactional
-  public YeopjeonHistory updateYeopjeonAndSaveYeopjeonHistory(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
-    YeopjeonHistory yeopjeonHistory;
-
-    updateMemberYeopjeon(member, action, rewardYeopjeon);
-
-    try {
-      yeopjeonHistory = yeopjeonHistoryService.saveYeopjeonHistory(member, action);
-      log.info("회원: {} 엽전 히스토리 저장 성공", member.getStudentId());
-    } catch (Exception e) {
-      log.error("회원: {} 엽전 히스토리 저장 시 오류가 발생했습니다. 오류내용: {}", member.getStudentId(), e.getMessage());
-      log.info("회원: {} 엽전 롤백을 진행합니다.", member.getStudentId());
-      rollbackYeopjeon(member, action, rewardYeopjeon);
-      throw new CustomException(ErrorCode.YEOPJEON_SAVE_ERROR);
-    }
-
-    return yeopjeonHistory;
-  }
-
-  // 엽전 및 엽전 히스토리 전체 롤백 (다른 메서드에서 문제가 발생했을 시 전체 롤백을 위한 메서드)
-  @Transactional
-  public void rollbackYeopjeonAndDeleteYeopjeonHistory(
-      Member member,
-      YeopjeonAction action,
-      YeopjeonHistory yeopjeonHistory) {
-    try {
-      log.info("회원: {} 엽전 롤백 및 엽전 내역 삭제를 진행합니다.", member.getStudentId());
-      yeopjeonHistoryService.deleteYeopjeonHistory(yeopjeonHistory);
-      rollbackYeopjeon(member, action, null);
-    } catch (Exception e) {
-      log.error("회원: {} 엽전 롤백 과정에서 오류가 발생했습니다.", member.getStudentId());
-      throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  // 엽전 및 엽전 히스토리 전체 롤백 (엽전 현상금 커스텀 가능할 경우)
-  @Transactional
-  public void rollbackYeopjeonAndDeleteYeopjeonHistory(
-      Member member,
-      YeopjeonAction action,
-      YeopjeonHistory yeopjeonHistory,
-      Integer rewardYeopjeon) {
-    try {
-      log.info("회원: {} 엽전 롤백 및 엽전 내역 삭제를 진행합니다.", member.getStudentId());
-      yeopjeonHistoryService.deleteYeopjeonHistory(yeopjeonHistory);
-      rollbackYeopjeon(member, action, rewardYeopjeon);
-    } catch (Exception e) {
-      log.error("회원: {} 엽전 롤백 과정에서 오류가 발생했습니다.", member.getStudentId());
-      throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  // 엽전 증감 로직
-  private void updateMemberYeopjeon(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
-
+  // 엽전 계산 및 검증
+  private int calculateAndValidateYeopjeon(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
     Yeopjeon yeopjeon = findMemberYeopjeon(member);
-
-    // 엽전 개수 변동
     int calculatedYeopjeon;
+
     if (action.equals(YeopjeonAction.REWARD_YEOPJEON)) {
       calculatedYeopjeon = yeopjeon.getYeopjeon() + yeopjeonCalculator.calculateYeopjeon(action, rewardYeopjeon);
     } else {
@@ -111,33 +68,55 @@ public class YeopjeonService {
     }
 
     if (calculatedYeopjeon < 0) {
-      log.error("엽전이 부족합니다. {}의 엽전 개수: {}", member.getStudentId(), yeopjeon.getYeopjeon());
+      log.error("엽전 부족: 회원 {}의 현재 엽전: {}", member.getStudentId(), yeopjeon.getYeopjeon());
       throw new CustomException(ErrorCode.INSUFFICIENT_YEOPJEON);
-    } else {
-      yeopjeon.updateYeopjeon(calculatedYeopjeon);
-      log.info("엽전 개수 변동 완료: {}의 엽전 개수 = {}", member.getStudentId(), yeopjeon.getYeopjeon());
     }
 
-    yeopjeonRepository.save(yeopjeon);
+    return calculatedYeopjeon;
   }
 
-  // 엽전 개수 롤백
-  private void rollbackYeopjeon(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
-
+  // 엽전 변동 적용
+  private void applyYeopjeonChanges(Member member, int newYeopjeon) {
     Yeopjeon yeopjeon = findMemberYeopjeon(member);
-
-    log.info("엽전 수 롤백 전 - 회원: {}, 엽전 수: {}", member.getStudentId(), yeopjeon.getYeopjeon());
-
-    if (action.equals(YeopjeonAction.REWARD_YEOPJEON)) {
-      yeopjeon.updateYeopjeon(yeopjeon.getYeopjeon() - yeopjeonCalculator.calculateYeopjeon(action, rewardYeopjeon));
-    } else {
-      yeopjeon.updateYeopjeon(yeopjeon.getYeopjeon() - yeopjeonCalculator.calculateYeopjeon(action));
-    }
-
-    log.info("엽전 수 롤백 후 - 회원: {}, 롤백 후 엽전 수: {}", member.getStudentId(), yeopjeon.getYeopjeon());
+    yeopjeon.setYeopjeon(newYeopjeon);
+    yeopjeonRepository.save(yeopjeon);
+    log.info("회원 {}의 엽전 변경 완료: 새로운 엽전 개수 = {}", member.getStudentId(), newYeopjeon);
   }
 
-  // 사용자의 엽전 테이블 반환 메서드
+  // 엽전 롤백
+  private void revertYeopjeonChange(Member member, YeopjeonAction action, Integer rewardYeopjeon) {
+    int rollbackAmount = rewardYeopjeon != null ? -rewardYeopjeon : 0;
+    log.info("회원 {}의 엽전 롤백 진행: 롤백 금액 = {}", member.getStudentId(), rollbackAmount);
+    Yeopjeon yeopjeon = findMemberYeopjeon(member);
+    int rollbackYeopjeon = calculateAndValidateYeopjeon(member, action, rollbackAmount);
+    applyYeopjeonChanges(member, rollbackYeopjeon);
+  }
+
+
+  /**
+   * 엽전 트랜잭션을 롤백하고 히스토리를 삭제하는 메서드
+   *
+   * @param member  롤백할 회원
+   * @param action  엽전 액션
+   * @param history 롤백할 엽전 히스토리
+   */
+  @Transactional
+  public void rollbackYeopjeonTransaction(Member member, YeopjeonAction action, YeopjeonHistory history) {
+    try {
+      // 엽전 히스토리 삭제
+      yeopjeonHistoryService.deleteYeopjeonHistory(history);
+      log.info("YeopjeonHistory 삭제 성공: HistoryId = {}", history.getYeopjeonHistoryId());
+
+      // 엽전 변경 되돌리기
+      revertYeopjeonChange(member, action, history.getYeopjeonChange());
+      log.info("Yeopjeon 변경 되돌리기: studentId = {}", member.getStudentId());
+    } catch (Exception e) {
+      log.error("Yeopjeon 변경 되돌리기 중 오류 발생: {}", e.getMessage());
+      throw new CustomException(ErrorCode.YEOPJEON_ROLLBACK_ERROR);
+    }
+  }
+
+  // 회원 엽전 정보 조회
   public Yeopjeon findMemberYeopjeon(Member member) {
     return yeopjeonRepository.findByMember(member)
         .orElseThrow(() -> new CustomException(ErrorCode.YEOPJEON_NOT_FOUND));
@@ -153,4 +132,5 @@ public class YeopjeonService {
 //    memberRepository.findTotalMemberCount();
     return yeopjeonRepository.findYeopjeonHolderCount(); // 전체 개수 가져오기
   }
+
 }

--- a/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
+++ b/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
@@ -186,6 +186,8 @@ public enum ErrorCode {
 
   INSUFFICIENT_YEOPJEON(HttpStatus.BAD_REQUEST, "사용자의 엽전이 부족합니다."),
 
+  YEOPJEON_ROLLBACK_ERROR(HttpStatus.BAD_REQUEST, "엽전 로직 롤백 중 오류가 발생하였습니다."),
+
   YEOPJEON_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "엽전 저장 시 오류가 발생했습니다."),
 
   YEOPJEON_HISTORY_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "엽전 히스토리 저장 중 오류가 발생했습니다."),

--- a/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
+++ b/src/main/java/com/balsamic/sejongmalsami/util/exception/ErrorCode.java
@@ -149,6 +149,10 @@ public enum ErrorCode {
 
   INVALID_ATTENDED_YEAR(HttpStatus.BAD_REQUEST, "적절하지않은 수강년도입니다"),
 
+  // DocumentFile
+
+  DOCUMENT_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "자료파일을 찾을 수 없습니다."),
+
   // DocumentRequestPost
 
   DOCUMENT_REQUEST_POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "자료 요청 글을 찾을 수 없습니다."),


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

1. 일단 지금로직에서 update보다 setter로 바꾸는게 맞는게 
update라는 메소드가 너무 많은데 이게 setter인지 이게 아니면 로직이 들어간건지 들어가봐야 아는게 너무불편합니다
이렇게 사용할꺼면 그냥 @Setter쓰는게 맞는것같아요 Setter 나쁜친구 아닙니다

2. updateYeopjeonAndSaveYeopjeonHistory() 이 메소드보다는 processYeopjeon 이렇게 바꾸고 
안에 다음과 같은식으로 4가지 스탭으로 적어놨습니다

<img width="699" alt="image" src="https://github.com/user-attachments/assets/bf52faf3-73da-495f-bd74-2a5fb05ce592">

3. 롤백 메소드 rollbackYeopjeonAndDeleteYeopjeonHistory 이렇게 표현하는것보다 rollbackYeopjeonTransaction 라고 표현하고
다음과 같이 2가지 스탭으로 구분했습니다

<img width="615" alt="image" src="https://github.com/user-attachments/assets/93f61057-5056-40f6-91b0-7de476375292">

이외는 순서가 바뀌었고 주석을 일관성있게 개선한것으로 변경사항없습니다

POST 질문글 작성시 예시 로그입니다

<img width="636" alt="image" src="https://github.com/user-attachments/assets/266da67c-2a54-46c3-b7af-aa5e28cb28b4">


<img width="679" alt="image" src="https://github.com/user-attachments/assets/308db45b-dba8-4d41-9171-6e9fa605abd8">


질문글 작성하는데 엽전 INSUFFICIENT_YEOPJEON 이 로직이

QuestionPostService쪽에있는데 이거 추후에 수정 부탁드립니다


<img width="1113" alt="image" src="https://github.com/user-attachments/assets/e26f3cac-3512-46f1-b562-292bb25af0a2">



EXP 로직도 개선 부탁
Like Service도 ContentType 받아서 하는걸로 수정해주세요 이슈제가 올려보겠습니다




## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
