### PR TITLE
시놀로지 외부 노출 도메인 CORS 및 Swagger 설정 반영 및 기존 도메인 삭제

### DIFF
--- a/SM-Web/src/main/java/com/balsamic/sejongmalsami/web/config/SwaggerConfig.java
+++ b/SM-Web/src/main/java/com/balsamic/sejongmalsami/web/config/SwaggerConfig.java
@@ -27,7 +27,9 @@ import org.springframework.context.annotation.Configuration;
     servers = {
         @Server(url = "https://api.sejong-malsami.co.kr", description = "메인 서버"),
         @Server(url = "https://api.test.sejong-malsami.co.kr", description = "테스트 서버"),
-        @Server(url = "http://localhost:8080", description = "로컬 서버")
+        @Server(url = "https://api.sejong-malsami.suhsaechan.kr", description = "시놀로지 API 서버"),
+        @Server(url = "http://localhost:8080", description = "로컬 서버 (8080)"),
+        @Server(url = "http://localhost:8087", description = "로컬 서버 (8087)")
     }
 )
 @Configuration
@@ -51,13 +53,19 @@ public class SwaggerConfig {
         .servers(List.of(
                 new io.swagger.v3.oas.models.servers.Server()
                     .url("http://localhost:8080")
-                    .description("로컬 서버"),
+                    .description("로컬 서버 (8080)"),
+                new io.swagger.v3.oas.models.servers.Server()
+                    .url("http://localhost:8087")
+                    .description("로컬 서버 (8087)"),
                 new io.swagger.v3.oas.models.servers.Server()
                     .url("https://api.test.sejong-malsami.co.kr")
                     .description("테스트 서버"),
                 new io.swagger.v3.oas.models.servers.Server()
                     .url("https://api.sejong-malsami.co.kr")
-                    .description("메인 서버")
+                    .description("메인 서버"),
+                new io.swagger.v3.oas.models.servers.Server()
+                    .url("https://api.sejong-malsami.suhsaechan.kr")
+                    .description("시놀로지 API 서버")
             )
         );
   }

--- a/SM-Web/src/main/java/com/balsamic/sejongmalsami/web/config/WebSecurityConfig.java
+++ b/SM-Web/src/main/java/com/balsamic/sejongmalsami/web/config/WebSecurityConfig.java
@@ -40,14 +40,12 @@ public class WebSecurityConfig {
    * 허용된 CORS Origin 목록
    */
   private static final String[] ALLOWED_ORIGINS = {
-      "https://api.sejong-malsami.co.kr",      // 운영 API 서버
-      "https://api.test.sejong-malsami.co.kr", // 테스트 API 서버
-      "https://www.sejong-malsami.co.kr",      // 운영 웹 서버
-      "https://test.sejong-malsami.co.kr",     // 테스트 웹 서버
-      "http://220.85.169.165:8086",            // 개발 API 서버
-      "http://220.85.169.165:3002",            // 개발 웹 서버
-      "http://localhost:8080",                 // 로컬 API 서버
-      "http://localhost:3000"                  // 로컬 웹 서버
+      "https://sejong-malsami.suhsaechan.kr",     // 시놀로지 외부 노출 웹 서버
+      "https://api.sejong-malsami.suhsaechan.kr", // 시놀로지 외부 노출 API 서버
+      "http://localhost:8080",                    // 로컬 API 서버
+      "http://localhost:8087",                    // 시놀로지/로컬 API 서버 (8087)
+      "http://localhost:3000",                    // 로컬 웹 서버
+      "http://localhost:3004"                     // 시놀로지/로컬 웹 서버 (3004)
   };
 
   /**

--- a/docs/suh-template/issue/20260617_#934_시놀로지_외부_노출_CORS_및_Swagger_설정_반영_및_기존_도메인_삭제.md
+++ b/docs/suh-template/issue/20260617_#934_시놀로지_외부_노출_CORS_및_Swagger_설정_반영_및_기존_도메인_삭제.md
@@ -1,0 +1,22 @@
+📝 현재 문제점
+---
+
+- 시놀로지 NAS 기반 외부 HTTPS(443) 노출 작업을 진행하며, 프론트엔드(`sejong-malsami.suhsaechan.kr`)와 백엔드(`api.sejong-malsami.suhsaechan.kr`)의 도메인이 신규 구축되었습니다.
+- 기존 CORS 허용 Origin 설정에 구버전 도메인 및 구서버 주소가 잔존하고 있어 원활한 신규 도메인 간 통신이 이루어지지 않고 CORS 에러가 발생합니다.
+- Swagger 설정 상에도 이전 서버 도메인 정보가 정의되어 있어 신규 구축된 API 도메인을 통한 Swagger UI 테스트가 불가합니다.
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- `WebSecurityConfig.java` 내의 기존 구버전 API 도메인 및 불필요한 IP 주소를 `ALLOWED_ORIGINS`에서 전면 제거합니다.
+- 시놀로지 외부 노출 도메인(`sejong-malsami.suhsaechan.kr`, `api.sejong-malsami.suhsaechan.kr`)과 새로운 로컬 개발 및 디버깅용 포트(`localhost:3004`, `localhost:8087`)를 추가하여 CORS를 완벽하게 허용합니다.
+- `SwaggerConfig.java`의 OpenAPI 서버 목록에 시놀로지 API 서버 도메인 및 로컬 포트 `8087`을 추가하여 Swagger 상에서 신규 API 도메인으로 정상 작동하게 만듭니다.
+
+⚙️ 작업 내용
+---
+- `WebSecurityConfig.java` 내 `ALLOWED_ORIGINS` 정리 및 업데이트 (구도메인 삭제, 신규 도메인/포트 추가)
+- `SwaggerConfig.java` 내 `@OpenAPIDefinition` 및 `openAPI()`의 OpenAPI 서버 리스트 업데이트 (구도메인 삭제, 신규 도메인/포트 추가)
+
+🙋‍♂️ 담당자
+---
+- 백엔드: Cassiiopeia


### PR DESCRIPTION
## 📝 작업 내용
- 시놀로지 외부 노출 HTTPS 환경에 따라 프론트엔드와 백엔드 간 CORS 연결 이슈를 해결하기 위해 `WebSecurityConfig.java` 내 `ALLOWED_ORIGINS` 재설정 및 기존 구버전 도메인 전면 제거
- 신규 API 서버 도메인(`api.sejong-malsami.suhsaechan.kr`)과 8087, 3004 로컬 개발/디버깅 포트의 CORS 허용 반영
- `SwaggerConfig.java`의 OpenAPI 서버 구성에 시놀로지 API 서버 및 로컬 8087 서버 설정을 추가하고 불필요한 이전 서버 목록 삭제

## 🔗 관련 이슈
- https://github.com/Sejong-Balsamic/Malsami-BE/issues/934


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 변경**
  * 시놀로지 외부 노출 도메인(api.sejong-malsami.suhsaechan.kr) 및 로컬 개발 포트에 대한 API 서버 설정 추가
  * 새로운 도메인과 로컬 포트(8087, 3004)에 대한 CORS 정책 업데이트
  * Swagger UI에서 새 API 환경으로의 요청 테스트 지원

* **문서**
  * 구성 변경 사항 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->