### PR TITLE
GitHub Actions 빌드 실패 유발하는 Secrets 직접 하드코딩 치환 구문 env 바인딩 방식으로 수정

### DIFF
--- a/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
+++ b/.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml
@@ -31,34 +31,46 @@ jobs:
           echo "$EMBEDDING_JSON" | sed 's/\n/\n/g' > ./SM-Web/src/main/resources/sejong-malsami-embedding.json
 
       - name: Create application-prod.yml from secret
+        env:
+          APPLICATION_PROD_YML: ${{ secrets.APPLICATION_PROD_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.APPLICATION_PROD_YML }}" > ./SM-Web/src/main/resources/application-prod.yml
+          echo "$APPLICATION_PROD_YML" > ./SM-Web/src/main/resources/application-prod.yml
 
       - name: Create yeopjeon.yml from secret
+        env:
+          YEOPJEON_YML: ${{ secrets.YEOPJEON_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.YEOPJEON_YML }}" > ./SM-Web/src/main/resources/yeopjeon.yml
+          echo "$YEOPJEON_YML" > ./SM-Web/src/main/resources/yeopjeon.yml
 
       - name: Create score.yml from secret
+        env:
+          SCORE_YML: ${{ secrets.SCORE_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.SCORE_YML }}" > ./SM-Web/src/main/resources/score.yml
+          echo "$SCORE_YML" > ./SM-Web/src/main/resources/score.yml
 
       - name: Create exp.yml from secret
+        env:
+          EXP_YML: ${{ secrets.EXP_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.EXP_YML }}" > ./SM-Web/src/main/resources/exp.yml
+          echo "$EXP_YML" > ./SM-Web/src/main/resources/exp.yml
 
       - name: Create admin.yml from secret
+        env:
+          ADMIN_YML: ${{ secrets.ADMIN_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.ADMIN_YML }}" > ./SM-Web/src/main/resources/admin.yml
+          echo "$ADMIN_YML" > ./SM-Web/src/main/resources/admin.yml
 
       - name: Create post-tier.yml from secret
+        env:
+          POSTTIER_YML: ${{ secrets.POSTTIER_YML }}
         run: |
           mkdir -p SM-Web/src/main/resources
-          echo "${{ secrets.POSTTIER_YML }}" > ./SM-Web/src/main/resources/post-tier.yml
+          echo "$POSTTIER_YML" > ./SM-Web/src/main/resources/post-tier.yml
 
       - name: Create Firebase Config File
         env:
@@ -68,9 +80,11 @@ jobs:
           echo "$FIREBASE_CONFIG_JSON" | sed 's/\\n/\n/g' > ./SM-Web/src/main/resources/firebase-admin-sdk.json
 
       - name: Create firebase-messaging-sw.js from secret
+        env:
+          FIREBASE_MESSAGING_SW_JS: ${{ secrets.FIREBASE_MESSAGING_SW_JS }}
         run: |
           mkdir -p SM-Web/src/main/resources/static
-          echo "${{ secrets.FIREBASE_MESSAGING_SW_JS }}" > ./SM-Web/src/main/resources/static/firebase-messaging-sw.js
+          echo "$FIREBASE_MESSAGING_SW_JS" > ./SM-Web/src/main/resources/static/firebase-messaging-sw.js
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test -Dspring.profiles.active=prod

--- a/docs/suh-template/issue/20260617_#936_Actions_빌드_실패_env_바인딩_방식으로_수정.md
+++ b/docs/suh-template/issue/20260617_#936_Actions_빌드_실패_env_바인딩_방식으로_수정.md
@@ -1,0 +1,27 @@
+📝 현재 문제점
+---
+
+- GitHub Actions 빌드 시 `mkdir -p SM-Web/src/main/resources`와 그 하위 yml 생성 스텝에서 `syntax error near unexpected token '('` 에러와 함께 빌드가 즉시 중단되는 현상이 발생했습니다.
+- 원인은 `SEJONG-MALSAMI-BE-CICD.yaml`의 여러 설정 파일 작성 스텝에서 GitHub Secrets를 환경 변수로 거치지 않고, `run` 블록 내 쉘 명령어 상에 `${{ secrets.XXX }}` 형태로 직접 텍스트 치환 주입하도록 정의해 두었기 때문입니다.
+- 이로 인해 시크릿 비밀값 내부에 포함되어 있던 괄호 `(` 및 `)` 또는 특수 문자가 쉘 해석 과정에서 이스케이프 없이 통째로 대입되어 쉘 스크립트 파싱 오류가 유발되었습니다.
+
+🛠️ 해결 방안 / 제안 기능
+---
+
+- GitHub Actions 공식 보안 권장 가이드에 따라, 모든 시크릿 주입 방식을 `run` 블록 하드코딩 치환 방식에서 `env:` 선언부를 통한 프로세스 환경 변수 바인딩 방식으로 변경합니다.
+- 쉘 내부에서는 `"$VAR_NAME"` 형태로 환경 변수를 참조하여 파일을 생성하도록 수정합니다. 이로써 값에 어떤 복잡한 특수기호나 줄바꿈이 섞여 있더라도 쉘 구문 오류를 완벽히 예방하고 시크릿의 로그 노출 위험을 원천 차단합니다.
+
+⚙️ 작업 내용
+---
+- `.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml` 파일 내 Secrets 주입 방식 전면 개편 (하드코딩 쉘 치환 ➡️ `env:`를 통한 변수 매핑 참조)
+  - `application-prod.yml`
+  - `yeopjeon.yml`
+  - `score.yml`
+  - `exp.yml`
+  - `admin.yml`
+  - `post-tier.yml`
+  - `firebase-messaging-sw.js`
+
+🙋‍♂️ 담당자
+---
+- DevOps: Cassiiopeia

--- a/docs/suh-template/troubleshoot/20260617_002_actions_syntax_error.md
+++ b/docs/suh-template/troubleshoot/20260617_002_actions_syntax_error.md
@@ -1,0 +1,22 @@
+### 문제 요약
+GitHub Actions 빌드 시 YAML 파일의 쉘 스크립트 문법 에러(`syntax error near unexpected token '('`)로 빌드 실패 | **타입**: CI/CD | **환경**: GitHub Actions (Ubuntu Runner)
+
+### 원인 분석
+**근본 원인**: `SEJONG-MALSAMI-BE-CICD.yaml`의 일부 스텝에서 GitHub Secrets의 값을 환경변수 매핑 없이 `run` 문맥 안에 직접 `${{ secrets.XXX }}` 형태로 주입하여 `echo "${{ secrets.XXX }}"`를 실행했습니다.
+
+**발생 메커니즘**:
+1. 특정 비밀값(예: `APPLICATION_PROD_YML` 등의 파일 내용) 내부에 괄호 `(` 및 `)` 또는 특수 문자가 포함되어 있었습니다.
+2. GitHub Actions가 스크립트 실행을 위한 임시 쉘 파일(`.sh`)을 작성할 때, 해당 비밀값 텍스트를 그대로 하드코딩 치환했습니다.
+3. 쉘 해석기(bash)가 이를 실행하는 과정에서 괄호 `(`를 만나자 올바르지 않은 쉘 구문으로 해석하여 `syntax error near unexpected token '('` 에러를 유발하며 프로세스가 즉시 실패했습니다.
+
+### 해결 방법
+#### Root Fix (권장)
+GitHub Actions 공식 보안 및 문법 권장 가이드에 따라, `secrets` 값을 `run` 쉘 스크립트 문자열에 직접 주입하지 않고, `env:` 블록을 통해 쉘 환경 변수로 주입합니다. 그런 다음 쉘 내부에서는 안전하게 변수 `"$VAR_NAME"` 형식을 사용하여 출력합니다.
+이 방식은 값에 어떠한 특수 문자(괄호, 쌍따옴표, $, ` 등)가 있더라도 쉘 구문 에러를 100% 방지하고 로그 및 프로세스 유출 위험도 완벽히 막아줍니다.
+
+### 검증
+1. `.github/workflows/SEJONG-MALSAMI-BE-CICD.yaml` 수정 반영 후 push하여 GitHub Actions 빌드 통과 여부 확인
+
+### 재발 방지
+- GitHub Actions의 `run` 블록 내에서 `${{ secrets.XXX }}`를 직접 호출하는 방식 지양
+- 항상 `env:` 블록을 거쳐 환경 변수로 사용하도록 표준 규격 수립


### PR DESCRIPTION
## 📝 작업 내용
- GitHub Actions 빌드 시 Secrets 평문 직접 치환 구문으로 인해 괄호 `(` 등이 문법 오류(`syntax error near unexpected token '('`)를 유발하는 문제를 해결하기 위해 Secrets 전체 주입 로직을 `env`를 경유하는 정석적인 쉘 변수 바인딩 방식으로 수정
- 해당 개선을 적용한 설정 대상:
  - `application-prod.yml`
  - `yeopjeon.yml`
  - `score.yml`
  - `exp.yml`
  - `admin.yml`
  - `post-tier.yml`
  - `firebase-messaging-sw.js`
- 쉘 소스 코드에 민감 값이 그대로 평문 노출되는 위험을 예방하고, 마스킹 안정성도 대폭 향상

## 🔗 관련 이슈
- https://github.com/Sejong-Balsamic/Malsami-BE/issues/936
